### PR TITLE
:pencil: fix time error

### DIFF
--- a/src/date.rs
+++ b/src/date.rs
@@ -41,7 +41,7 @@ struct Date {
 impl Date {
     fn new() -> Date {
         let format = time::format_description::parse(
-            "[weekday repr:short], [day] [month repr:short] [year] [hour]:[minute]:[second] GMT",
+            "[weekday repr:short], [day] [month repr:short] [year] [hour]:[minute]:[second] UTC",
         )
         .unwrap();
         let mut date = Date {


### PR DESCRIPTION
In your code, you update the date and time using `time::OffsetDateTime::now_utc()`, but you return the time as in a different time zone (GMT)