### PR TITLE
docs(README.md): add benchmark link

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Requests/sec: 116181.73
 Transfer/sec:     11.41MB
 ```
 
+## Benchmarks
+
+One of the fastest web frameworks available according to the [TechEmpower Framework Benchmark](https://www.techempower.com/benchmarks/#section=data-r21&test=composite).
+
 # License
 
 This project is licensed under either of


### PR DESCRIPTION
Benchmarking with other frameworks makes this framework cool and more competitive. People would likely to try to experiment and try to learn about this framework, primarily performance nerd like me.